### PR TITLE
Add an endpoint that supports generics

### DIFF
--- a/SimpleMediator/Core/IMediator.cs
+++ b/SimpleMediator/Core/IMediator.cs
@@ -5,7 +5,11 @@ namespace SimpleMediator.Core
 {
     public interface IMediator
     {
-        Task<TResponse> HandleAsync<TResponse>(IMessage<TResponse> message, IMediationContext mediationContext = default(IMediationContext),
+        Task<TResponse> HandleAsync<TResponse>(IMessage<TResponse> message,
+            IMediationContext mediationContext = default(IMediationContext),
             CancellationToken cancellationToken = default(CancellationToken));
+        Task<TResponse> HandleAsync<TMessage, TResponse>(TMessage message,
+            IMediationContext mediationContext = default(IMediationContext),
+            CancellationToken cancellationToken = default(CancellationToken)) where TMessage : IMessage<TResponse>;
     }
 }


### PR DESCRIPTION
This will be slightly faster than using reflection to figure out the request type.

But the calling signature has to be explicit in defining the <message,response>

```csharp
     // without generics
       var result = await mediator.HandleAsync(simpleQuery, context);

     // with generics
      var result = await mediator.HandleAsync<SimpleQuery, SimpleResponse>(simpleQuery, context);
```